### PR TITLE
Improve TTL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# VSCode
+.vscode/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ table_config = DynamoDBTableConfig(
     billing_mode=BillingMode.PAY_PER_REQUEST,  # PAY_PER_REQUEST or PROVISIONED
     enable_encryption=True,  # Enable server-side encryption
     enable_point_in_time_recovery=False,  # Enable point-in-time recovery
-    enable_ttl=False,  # Enable TTL for items
-    ttl_attribute="ttl",  # TTL attribute name
+    ttl_days=30,  # Enable TTL with 30 days expiration (set to None to disable)
+    ttl_attribute="expireAt",  # TTL attribute name
     
     # For PROVISIONED billing mode only:
     read_capacity=None,  # Provisioned read capacity units

--- a/langgraph_checkpoint_dynamodb/config.py
+++ b/langgraph_checkpoint_dynamodb/config.py
@@ -16,8 +16,10 @@ class DynamoDBTableConfig:
     billing_mode: BillingMode = BillingMode.PAY_PER_REQUEST
     enable_encryption: bool = True
     enable_point_in_time_recovery: bool = False
-    enable_ttl: bool = False
-    ttl_attribute: str = "ttl"
+
+    # CAUTION: once TTL is enabled, attribute will be added to all items without it
+    ttl_attribute: str = "expireAt"
+    ttl_days: Optional[int] = None  # set a positive number to enable TTL
 
     # For provisioned capacity mode
     read_capacity: Optional[int] = None
@@ -36,6 +38,9 @@ class DynamoDBTableConfig:
                 raise ValueError(
                     "read_capacity and write_capacity required for PROVISIONED mode"
                 )
+
+        if self.ttl_days is not None and self.ttl_days <= 0:
+            raise ValueError("ttl_days must be positive when specified")
 
 
 @dataclass

--- a/langgraph_checkpoint_dynamodb/constants.py
+++ b/langgraph_checkpoint_dynamodb/constants.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Optional, TypedDict, Union
+from boto3.dynamodb.types import Binary
 
 
 class ItemType(str, Enum):
@@ -9,28 +10,32 @@ class ItemType(str, Enum):
     WRITE = "write"
 
 
-class CheckpointItem(TypedDict):
-    """Type definition for checkpoint items."""
+# total=False: allow extra fields like TTL
+class CheckpointItem(TypedDict, total=False):
+    """Type for DynamoDB checkpoint items."""
 
     PK: str
     SK: str
-    type: str  # Serialization type
+    type: str
     checkpoint_id: str
-    checkpoint: str  # Serialized data
-    metadata: str  # Serialized data
+    checkpoint: Union[str, Binary]
+    metadata: Union[str, Binary]
     parent_checkpoint_id: Optional[str]
+    # TTL attribute will be added dynamically with the configured name
 
 
-class WriteItem(TypedDict):
-    """Type definition for write items."""
+# total=False: allow extra fields like TTL
+class WriteItem(TypedDict, total=False):
+    """Type for DynamoDB write items."""
 
     PK: str
     SK: str
-    type: str  # Serialization type
+    type: str
     task_id: str
     channel: str
-    value: str  # Serialized data
+    value: Union[str, Binary]
     idx: int
+    # TTL attribute will be added dynamically with the configured name
 
 
 DynamoDBItem = Union[CheckpointItem, WriteItem]

--- a/langgraph_checkpoint_dynamodb/infra/checkpoint_stack.py
+++ b/langgraph_checkpoint_dynamodb/infra/checkpoint_stack.py
@@ -72,7 +72,9 @@ class DynamoDBCheckpointStack(Stack):
         table = dynamodb.Table(self, "CheckpointTable", **table_config)
         
         # Enable TTL if configured
-        if self.props.enable_ttl:
+        if self.props.ttl_days is not None:
+            if not self.props.ttl_attribute:
+                raise ValueError("ttl_attribute is required when ttl_days is set")
             table.add_time_to_live_attribute(self.props.ttl_attribute)
             
         return table

--- a/langgraph_checkpoint_dynamodb/tests/unit/test_saver.py
+++ b/langgraph_checkpoint_dynamodb/tests/unit/test_saver.py
@@ -1,17 +1,19 @@
+import operator
+
 import pytest
-from moto import mock_aws
-from langchain_core.messages import HumanMessage, AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import CheckpointTuple
+from langgraph.graph import END, START, MessageGraph, StateGraph
+from moto import mock_aws
+from typing_extensions import Annotated, TypedDict
+
 from langgraph_checkpoint_dynamodb import (
+    DynamoDBConfig,
     DynamoDBSaver,
     DynamoDBTableConfig,
-    DynamoDBConfig,
 )
 from langgraph_checkpoint_dynamodb.config import BillingMode
-from langgraph.graph import END, START, MessageGraph, StateGraph
-from typing_extensions import Annotated, TypedDict
-import operator
 
 # Configure pytest-asyncio to use function scope for event loops
 pytest.mark.asyncio.loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-checkpoint-amazon-dynamodb"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     { name = "Aaron Su", email = "supaaron@amazon.com" },
 ]


### PR DESCRIPTION
Enable DynamoDB time-to-live (TTL) by specifying ttl_days and ttl_attribute in the DynamoDBTableConfig (see [README](https://github.com/aaronsu11/langgraph-checkpoint-dynamodb?tab=readme-ov-file#dynamodb-table-configuration-options) for example usage). Checkpoints and Writes will be deleted (after some delay) by DynamoDB automatically after time passes the timestamp value under the ttl_attribute.